### PR TITLE
added a require state to populate `mime` when not using openResty

### DIFF
--- a/tls-mailer.lua
+++ b/tls-mailer.lua
@@ -20,6 +20,7 @@ if is_openresty then
 else
 
   socket = require "socket"
+  mime = require "mime"
   smtp = require "socket.smtp"
   ltn12 = require "ltn12"
   ssl = require "ssl"


### PR DESCRIPTION
This was failing on my install, via luarocks of the tls-mailer package.  Without openResty `mime` wasn't defined.  It was just missing the require.